### PR TITLE
change connectionId prameter for delete chat by connection id from string to number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@innobridge/lexiclient",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@innobridge/lexiclient",
-      "version": "0.0.0",
+      "version": "0.0.3",
       "license": "InnoBridge",
       "dependencies": {
         "@innobridge/trpcmessengerclient": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/lexiclient",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Client side(React Native) code to @innobridge/lexi",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/cached_chats.ts
+++ b/src/api/cached_chats.ts
@@ -36,7 +36,7 @@ const deleteChat = async (chatId: string): Promise<void> => {
     return await cacheClient.deleteChat(chatId);
 };
 
-const deleteChatByConnectionId = async (connectionId: string): Promise<void> => {
+const deleteChatByConnectionId = async (connectionId: number): Promise<void> => {
     if (!cacheClient) {
         throw new Error("Cache client not initialized. Call initializeCache first.");
     }

--- a/src/storage/cached_chats_client.ts
+++ b/src/storage/cached_chats_client.ts
@@ -7,7 +7,7 @@ interface CachedChatsClient extends CachedBaseClient {
     getChatsByUserId(userId: string, updatedAfter?: number, desc?: boolean): Promise<Chat[]>;
     upsertChats(chats: Chat[]): Promise<void>;
     deleteChat(chatId: string): Promise<void>;
-    deleteChatByConnectionId(connectionId: string): Promise<void>;
+    deleteChatByConnectionId(connectionId: number): Promise<void>;
     deleteAllChats(): Promise<void>;
     getMessagesByChatId(chatId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;
     getMessagesByUserId(userId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;

--- a/src/storage/sqllite_chats_client.ts
+++ b/src/storage/sqllite_chats_client.ts
@@ -98,7 +98,7 @@ class SqlliteChatsClient extends SqlliteBaseClient implements CachedChatsClient 
         }
     }
 
-    async deleteChatByConnectionId(connectionId: string): Promise<void> {
+    async deleteChatByConnectionId(connectionId: number): Promise<void> {
         try {
             await this.runAsync(DELETE_CHAT_BY_CONNECTION_ID_QUERY, [connectionId]);
         } catch (error) {


### PR DESCRIPTION
This pull request includes updates to the `@innobridge/lexiclient` package version and refactors the `deleteChatByConnectionId` method across multiple files to change the `connectionId` parameter type from `string` to `number`.

### Package Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.2` to `0.0.3`.

### Refactoring `deleteChatByConnectionId` Method:
* [`src/api/cached_chats.ts`](diffhunk://#diff-42e078a92950564ae646bfaaba5161de15b4b5aaaf4731b94ccc702595ad0168L39-R39): Changed the `connectionId` parameter type in the `deleteChatByConnectionId` function from `string` to `number`.
* [`src/storage/cached_chats_client.ts`](diffhunk://#diff-40f61411c363bdf7bdb89722260d28835152eb7a575cfcc818665d8196d3c0edL10-R10): Updated the `deleteChatByConnectionId` method in the `CachedChatsClient` interface to use `number` as the type for `connectionId`.
* [`src/storage/sqllite_chats_client.ts`](diffhunk://#diff-490901e773a58aef12c0237bec745755db3a45bb9ef6cce637cbd4e0ec8f73dbL101-R101): Modified the `deleteChatByConnectionId` method in the `SqlliteChatsClient` class to accept `connectionId` as a `number` instead of a `string`.