### PR TITLE
fix connectionid from string to number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/lexiclient",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Client side(React Native) code to @innobridge/lexi",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/cached_chats.ts
+++ b/src/api/cached_chats.ts
@@ -1,7 +1,7 @@
 import { cacheClient } from "@/api/cache";
 import { Chat, Message } from "@/models/chats";
 
-const getChatByConnectionId = async (connectionId: string): Promise<Chat | null> => {
+const getChatByConnectionId = async (connectionId: number): Promise<Chat | null> => {
     if (!cacheClient) {
         throw new Error("Cache client not initialized. Call initializeCache first.");
     }
@@ -64,7 +64,7 @@ const getMessagesByUserId = async (userId: string, createdAfter?: number, limit?
     return await cacheClient.getMessagesByUserId(userId, createdAfter, limit, offset, desc);
 };
 
-const getMessagesByConnectionId = async (connectionId: string, createdAfter?: number, limit?: number, offset?: number, desc: boolean = true): Promise<Message[]> => {
+const getMessagesByConnectionId = async (connectionId: number, createdAfter?: number, limit?: number, offset?: number, desc: boolean = true): Promise<Message[]> => {
     if (!cacheClient) {
         throw new Error("Cache client not initialized. Call initializeCache first.");
     }

--- a/src/storage/cached_chats_client.ts
+++ b/src/storage/cached_chats_client.ts
@@ -2,7 +2,7 @@ import { CachedBaseClient  } from "@/storage/cached_base_client";
 import { Chat, Message } from "@/models/chats";
 
 interface CachedChatsClient extends CachedBaseClient {
-    getChatByConnectionId(connectionId: string): Promise<Chat | null>
+    getChatByConnectionId(connectionId: number): Promise<Chat | null>
     getChatByChatId(chatId: string): Promise<Chat | null>;
     getChatsByUserId(userId: string, updatedAfter?: number, desc?: boolean): Promise<Chat[]>;
     upsertChats(chats: Chat[]): Promise<void>;
@@ -11,7 +11,7 @@ interface CachedChatsClient extends CachedBaseClient {
     deleteAllChats(): Promise<void>;
     getMessagesByChatId(chatId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;
     getMessagesByUserId(userId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;
-    getMessagesByConnectionId(connectionId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;
+    getMessagesByConnectionId(connectionId: number, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;
     upsertMessages(messages: Message[]): Promise<void>;
 };
 

--- a/src/storage/sqllite_chats_client.ts
+++ b/src/storage/sqllite_chats_client.ts
@@ -52,7 +52,7 @@ class SqlliteChatsClient extends SqlliteBaseClient implements CachedChatsClient 
         return await this.execAsync(CREATE_MESSAGES_TABLE_QUERY);
     }
 
-    async getChatByConnectionId(connectionId: string): Promise<Chat | null> {
+    async getChatByConnectionId(connectionId: number): Promise<Chat | null> {
         const result = await this.getFirstAsync(GET_CHAT_BY_CONNECTION_ID_QUERY, [connectionId]);
         return result ? mapToChat(result) : null;
     }
@@ -128,7 +128,7 @@ class SqlliteChatsClient extends SqlliteBaseClient implements CachedChatsClient 
         return result.map(mapToMessage);
     }
 
-    async getMessagesByConnectionId(connectionId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]> {
+    async getMessagesByConnectionId(connectionId: number, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]> {
         const query = GET_MESSAGES_BY_CONNECTION_ID_QUERY(createdAfter, limit, offset, desc);
         const result = await this.getAllAsync(query, [connectionId]);
         return result.map(mapToMessage);


### PR DESCRIPTION
This pull request includes updates to the `@innobridge/lexiclient` package version and refactors several methods and interfaces to use `number` instead of `string` for `connectionId`. These changes improve type consistency across the codebase and align with expected data formats.

### Package Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.3` to `0.0.4`.

### Refactoring for Type Consistency:
#### API Changes:
* [`src/api/cached_chats.ts`](diffhunk://#diff-42e078a92950564ae646bfaaba5161de15b4b5aaaf4731b94ccc702595ad0168L4-R4): Updated the `connectionId` parameter type from `string` to `number` in the `getChatByConnectionId` and `getMessagesByConnectionId` methods. [[1]](diffhunk://#diff-42e078a92950564ae646bfaaba5161de15b4b5aaaf4731b94ccc702595ad0168L4-R4) [[2]](diffhunk://#diff-42e078a92950564ae646bfaaba5161de15b4b5aaaf4731b94ccc702595ad0168L67-R67)

#### Interface Updates:
* [`src/storage/cached_chats_client.ts`](diffhunk://#diff-40f61411c363bdf7bdb89722260d28835152eb7a575cfcc818665d8196d3c0edL5-R5): Updated the `connectionId` parameter type from `string` to `number` in the `CachedChatsClient` interface for `getChatByConnectionId` and `getMessagesByConnectionId` methods. [[1]](diffhunk://#diff-40f61411c363bdf7bdb89722260d28835152eb7a575cfcc818665d8196d3c0edL5-R5) [[2]](diffhunk://#diff-40f61411c363bdf7bdb89722260d28835152eb7a575cfcc818665d8196d3c0edL14-R14)

#### SQLite Client Changes:
* [`src/storage/sqllite_chats_client.ts`](diffhunk://#diff-490901e773a58aef12c0237bec745755db3a45bb9ef6cce637cbd4e0ec8f73dbL55-R55): Updated the `connectionId` parameter type from `string` to `number` in the `SqlliteChatsClient` implementation for `getChatByConnectionId` and `getMessagesByConnectionId` methods. [[1]](diffhunk://#diff-490901e773a58aef12c0237bec745755db3a45bb9ef6cce637cbd4e0ec8f73dbL55-R55) [[2]](diffhunk://#diff-490901e773a58aef12c0237bec745755db3a45bb9ef6cce637cbd4e0ec8f73dbL131-R131)