### PR TITLE
change connectionid in chat from string to number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@innobridge/lexiclient",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@innobridge/lexiclient",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "InnoBridge",
       "dependencies": {
-        "@innobridge/trpcmessengerclient": "^0.3.0"
+        "@innobridge/trpcmessengerclient": "^0.3.3"
       },
       "devDependencies": {
         "@types/node": "^22.15.29",
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/@innobridge/trpcmessengerclient": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@innobridge/trpcmessengerclient/-/trpcmessengerclient-0.3.0.tgz",
-      "integrity": "sha512-51flreKe6pGSyTIF7gzv0HzurL1N4ZHy5SJuWmF+MzFYSRJVJo9D9H6dFqHQl2LxK2AoawBKmZ3YSP4K8UicgQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@innobridge/trpcmessengerclient/-/trpcmessengerclient-0.3.3.tgz",
+      "integrity": "sha512-LtLh73eAEQEC5Gt4BDfBlQkTmVUerPrbqziq0HNcIOfaDjf06d0nyS6HFokxFM/9HcNvTLSB4gccINm34xkpkg==",
       "license": "InnoBridge",
       "dependencies": {
         "@trpc/client": "^11.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/lexiclient",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Client side(React Native) code to @innobridge/lexi",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {
@@ -54,6 +54,6 @@
     "node": "^20.0.0 || >=22.0.0"
   },
   "dependencies": {
-    "@innobridge/trpcmessengerclient": "^0.3.0"
+    "@innobridge/trpcmessengerclient": "^0.3.3"
   }
 }

--- a/src/models/chats.ts
+++ b/src/models/chats.ts
@@ -1,6 +1,6 @@
 interface Chat {
   chatId: string;
-  connectionId: string;
+  connectionId: number;
   userId1: string;
   userId2: string;
   createdAt: number;


### PR DESCRIPTION
This pull request includes updates to the `package.json` file and a type change in the `Chat` interface within `src/models/chats.ts`. The changes address version updates and type corrections.

### Dependency and version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.4` to `0.0.5` to reflect a new release.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L57-R57): Updated the dependency `@innobridge/trpcmessengerclient` from version `^0.3.0` to `^0.3.3`.

### Type correction:

* [`src/models/chats.ts`](diffhunk://#diff-7bb6f975df973a4275fce5d97904f4d3d0b89605d9ac3ff044c0f5d2b45555a0L3-R3): Changed the type of `connectionId` in the `Chat` interface from `string` to `number` to ensure type consistency.