### PR TITLE
add unread message count api, mark message as read on get operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/lexiclient",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Client side(React Native) code to @innobridge/lexi",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/cached_chats.ts
+++ b/src/api/cached_chats.ts
@@ -50,6 +50,13 @@ const deleteAllChats = async (): Promise<void> => {
     return await cacheClient.deleteAllChats();
 };
 
+const getUnreadMessagesCountByConnectionId = async (connectionId: number): Promise<number> => {
+    if (!cacheClient) {
+        throw new Error("Cache client not initialized. Call initializeCache first.");
+    }
+    return await cacheClient.getUnreadMessagesCountByConnectionId(connectionId);
+};
+
 const getMessagesByChatId = async (chatId: string, createdAfter?: number, limit?: number, offset?: number, desc: boolean = true): Promise<Message[]> => {
     if (!cacheClient) {
         throw new Error("Cache client not initialized. Call initializeCache first.");
@@ -86,6 +93,7 @@ export {
     deleteChat,
     deleteChatByConnectionId,
     deleteAllChats,
+    getUnreadMessagesCountByConnectionId,
     getMessagesByChatId,
     getMessagesByUserId,
     getMessagesByConnectionId,

--- a/src/storage/cached_chats_client.ts
+++ b/src/storage/cached_chats_client.ts
@@ -9,6 +9,7 @@ interface CachedChatsClient extends CachedBaseClient {
     deleteChat(chatId: string): Promise<void>;
     deleteChatByConnectionId(connectionId: number): Promise<void>;
     deleteAllChats(): Promise<void>;
+    getUnreadMessagesCountByConnectionId(connectionId: number): Promise<number>;
     getMessagesByChatId(chatId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;
     getMessagesByUserId(userId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;
     getMessagesByConnectionId(connectionId: number, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]>;

--- a/src/storage/queries.ts
+++ b/src/storage/queries.ts
@@ -83,6 +83,12 @@ const DELETE_CHAT_BY_CONNECTION_ID_QUERY =
 const DELETE_ALL_CHATS_QUERY =
     `DELETE FROM chats`;
 
+const GET_UNREAD_MESSAGES_COUNT_BY_CONNECTION_ID_QUERY = 
+    `SELECT COUNT(*) as unread_count 
+     FROM messages m
+     JOIN chats c ON m.chat_id = c.chat_id
+     WHERE c.connection_id = ? AND m.is_read = 0`;
+
 const GET_MESSAGES_BY_CHAT_ID_QUERY = (createdAfter?: number, limit?: number, offset?: number, desc: boolean = true) => {
     const createdAfterCondition = createdAfter ? 'AND created_at > ?' : '';
     const limitClause = limit ? `LIMIT ${limit}` : '';
@@ -124,6 +130,12 @@ const GET_MESSAGES_BY_CONNECTION_ID_QUERY = (createdAfter?: number, limit?: numb
             ${limitClause} ${offsetClause}`;
 };
 
+const UPDATE_MESSAGES_AS_READ_BY_MESSAGE_IDS_QUERY = (messageCount: number): string => {
+    const placeholders = Array(messageCount).fill('?').join(', ');
+    return `UPDATE messages SET is_read = 1 
+            WHERE message_id IN (${placeholders})`;
+};
+
 const UPSERT_MESSAGES_QUERY = (messageCount: number): string => {
     const placeholders = Array(messageCount).fill('(?, ?, ?, ?, ?, ?)').join(', ');
     return `INSERT INTO messages (message_id, chat_id, sender_id, content, is_read, created_at)
@@ -150,8 +162,10 @@ export {
     DELETE_CHAT_QUERY,
     DELETE_CHAT_BY_CONNECTION_ID_QUERY,
     DELETE_ALL_CHATS_QUERY,
+    GET_UNREAD_MESSAGES_COUNT_BY_CONNECTION_ID_QUERY,
     GET_MESSAGES_BY_CHAT_ID_QUERY,
     GET_MESSAGES_BY_USER_ID_QUERY,
     GET_MESSAGES_BY_CONNECTION_ID_QUERY,
+    UPDATE_MESSAGES_AS_READ_BY_MESSAGE_IDS_QUERY,
     UPSERT_MESSAGES_QUERY
 };

--- a/src/storage/sqllite_chats_client.ts
+++ b/src/storage/sqllite_chats_client.ts
@@ -131,7 +131,7 @@ class SqlliteChatsClient extends SqlliteBaseClient implements CachedChatsClient 
     async getUnreadMessagesCountByConnectionId(connectionId: number): Promise<number> {
         const result = await this.getFirstAsync(GET_UNREAD_MESSAGES_COUNT_BY_CONNECTION_ID_QUERY, [connectionId]);
         return result ? (result as { unread_count: number }).unread_count : 0;
-    };
+    }
 
     async getMessagesByChatId(chatId: string, createdAfter?: number, limit?: number, offset?: number, desc?: boolean): Promise<Message[]> {
         try {
@@ -143,7 +143,7 @@ class SqlliteChatsClient extends SqlliteBaseClient implements CachedChatsClient 
                 return [];
             }
             const messageIds = result.map((row: any) => row.message_id);
-            this.updateMessagesAsReadByMessageIds(messageIds);
+            await this.updateMessagesAsReadByMessageIds(messageIds);
             await this.commitTransaction();
             return result.map(mapToMessage);
         } catch (error) {
@@ -169,7 +169,7 @@ class SqlliteChatsClient extends SqlliteBaseClient implements CachedChatsClient 
                 return [];
             }
             const messageIds = result.map((row: any) => row.message_id);
-            this.updateMessagesAsReadByMessageIds(messageIds);
+            await this.updateMessagesAsReadByMessageIds(messageIds);
             await this.commitTransaction();
             return result.map(mapToMessage);
         } catch (error) {


### PR DESCRIPTION
This pull request introduces enhancements to the chat caching and storage functionality, focusing on unread message counts and marking messages as read. The most important changes include adding methods to retrieve unread message counts by connection ID, implementing transaction-based updates for marking messages as read, and updating queries to support these functionalities.

### New functionality for unread messages:

* [`src/api/cached_chats.ts`](diffhunk://#diff-42e078a92950564ae646bfaaba5161de15b4b5aaaf4731b94ccc702595ad0168R53-R59): Added `getUnreadMessagesCountByConnectionId` function to fetch the count of unread messages for a specific connection ID. [[1]](diffhunk://#diff-42e078a92950564ae646bfaaba5161de15b4b5aaaf4731b94ccc702595ad0168R53-R59) [[2]](diffhunk://#diff-42e078a92950564ae646bfaaba5161de15b4b5aaaf4731b94ccc702595ad0168R96)
* [`src/storage/cached_chats_client.ts`](diffhunk://#diff-40f61411c363bdf7bdb89722260d28835152eb7a575cfcc818665d8196d3c0edR12): Extended the `CachedChatsClient` interface to include `getUnreadMessagesCountByConnectionId`.
* [`src/storage/queries.ts`](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436R86-R91): Added `GET_UNREAD_MESSAGES_COUNT_BY_CONNECTION_ID_QUERY` to retrieve unread message counts from the database. [[1]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436R86-R91) [[2]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436R165-R169)

### Marking messages as read:

* [`src/storage/queries.ts`](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436R133-R138): Added `UPDATE_MESSAGES_AS_READ_BY_MESSAGE_IDS_QUERY` to update messages as read based on their IDs. [[1]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436R133-R138) [[2]](diffhunk://#diff-07cf16a57a572dd852cca35f86704767bb814e5cd47caf3c3e85d2d4a59c4436R165-R169)
* [`src/storage/sqllite_chats_client.ts`](diffhunk://#diff-490901e773a58aef12c0237bec745755db3a45bb9ef6cce637cbd4e0ec8f73dbR131-R153): Implemented `updateMessagesAsReadByMessageIds` private method and integrated it into `getMessagesByChatId` and `getMessagesByConnectionId` methods with transaction handling to mark retrieved messages as read. [[1]](diffhunk://#diff-490901e773a58aef12c0237bec745755db3a45bb9ef6cce637cbd4e0ec8f73dbR131-R153) [[2]](diffhunk://#diff-490901e773a58aef12c0237bec745755db3a45bb9ef6cce637cbd4e0ec8f73dbR163-R179) [[3]](diffhunk://#diff-490901e773a58aef12c0237bec745755db3a45bb9ef6cce637cbd4e0ec8f73dbR202-R214)

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.7` to `0.0.8` to reflect the new changes.